### PR TITLE
Fix profanity import path

### DIFF
--- a/app/api/generate-punchlines/route.ts
+++ b/app/api/generate-punchlines/route.ts
@@ -4,7 +4,7 @@ import { Redis } from '@upstash/redis';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import OpenAI from 'openai';
-import { profanity } from '@/lib//profanity';
+import { profanity } from '@/lib/profanity';
 import { getIp, RATE_LIMIT_TOKENS, RATE_LIMIT_WINDOW } from '@/lib/rate-limit';
 import { addPunchlinesToDb } from '@/lib/supabase-admin';
 import { SuggestResponse } from '@/types';


### PR DESCRIPTION
## Summary
- fix the profanity import path used by the API

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_68589ab2123c8324a8207abb6266e38d