### PR TITLE
Add info to account page

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -2,26 +2,19 @@ import { redirect } from 'next/navigation';
 import { Container } from '@/components/Container';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
-import {
-  getSubscription,
-  getUser,
-  getUserJokes
-} from '@/lib/supabase-server';
+import { getSubscription, getUser } from '@/lib/supabase-server';
 import { UpdateSubscriptionButton } from './components/UpdateSubscriptionButton';
 
 export default async function AccountPage() {
-  const [user, subscription, jokes] = await Promise.all([
+  const [user, subscription] = await Promise.all([
     getUser(),
-    getSubscription(),
-    getUserJokes()
+    getSubscription()
   ]);
 
   if (user == null) return redirect('/');
 
   const joinedDate = formatDate(user.created_at);
-  const lastSignIn = formatDate(user.last_sign_in_at);
   const hasSubscription = subscription != null;
-  const savedJokesCount = jokes?.length ?? 0;
 
   return (
     <Container>
@@ -29,17 +22,11 @@ export default async function AccountPage() {
       <div className="border-t border-gray-200 pt-8 space-y-6">
         <div className="space-y-2">
           <h2 className="text-sm font-bold uppercase tracking-wider">
-            Account Info
+            Account Details
           </h2>
-          {joinedDate != null && (
-            <p className="text-sm">Joined {joinedDate}.</p>
-          )}
           {user.email && <p className="text-sm">Email: {user.email}</p>}
-          {lastSignIn && (
-            <p className="text-sm">Last sign in {lastSignIn}.</p>
-          )}
-          {savedJokesCount > 0 && (
-            <p className="text-sm">Saved jokes: {savedJokesCount}</p>
+          {joinedDate != null && (
+            <p className="text-sm">Joined: {joinedDate}</p>
           )}
         </div>
         <div className="space-y-2">

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -2,32 +2,46 @@ import { redirect } from 'next/navigation';
 import { Container } from '@/components/Container';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
-import { getSubscription, getUser } from '@/lib/supabase-server';
+import {
+  getSubscription,
+  getUser,
+  getUserJokes
+} from '@/lib/supabase-server';
 import { UpdateSubscriptionButton } from './components/UpdateSubscriptionButton';
 
 export default async function AccountPage() {
-  const [user, subscription] = await Promise.all([
+  const [user, subscription, jokes] = await Promise.all([
     getUser(),
-    getSubscription()
+    getSubscription(),
+    getUserJokes()
   ]);
 
   if (user == null) return redirect('/');
 
   const joinedDate = formatDate(user.created_at);
+  const lastSignIn = formatDate(user.last_sign_in_at);
   const hasSubscription = subscription != null;
+  const savedJokesCount = jokes?.length ?? 0;
 
   return (
     <Container>
       <Header />
       <div className="border-t border-gray-200 pt-8 space-y-6">
-        {joinedDate != null && (
-          <div className="space-y-2">
-            <h2 className="text-sm font-bold uppercase tracking-wider">
-              Account Info
-            </h2>
+        <div className="space-y-2">
+          <h2 className="text-sm font-bold uppercase tracking-wider">
+            Account Info
+          </h2>
+          {joinedDate != null && (
             <p className="text-sm">Joined {joinedDate}.</p>
-          </div>
-        )}
+          )}
+          {user.email && <p className="text-sm">Email: {user.email}</p>}
+          {lastSignIn && (
+            <p className="text-sm">Last sign in {lastSignIn}.</p>
+          )}
+          {savedJokesCount > 0 && (
+            <p className="text-sm">Saved jokes: {savedJokesCount}</p>
+          )}
+        </div>
         <div className="space-y-2">
           <h3 className="text-sm font-bold uppercase tracking-wider">
             Subscription

--- a/components/UserDropdown.tsx
+++ b/components/UserDropdown.tsx
@@ -63,7 +63,9 @@ export function UserDropdown({
         <DropdownMenuItem asChild>
           <Link href="/saved">Saved jokes</Link>
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/account">Account details</Link>
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={signOut}>Log out</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- extend account page server logic to also fetch saved jokes
- show last sign-in, email, and saved joke count on account page

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6859495fb3888324b432f0b33780f0fb