### PR TITLE
Fix account page redirect when not logged in

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -11,7 +11,7 @@ export default async function AccountPage() {
     getSubscription()
   ]);
 
-  if (user == null) return redirect('/');
+  if (user == null) return redirect('/sign-in');
 
   const joinedDate = formatDate(user.created_at);
   const hasSubscription = subscription != null;


### PR DESCRIPTION
## Summary
- redirect visitors to the sign-in page if they visit the account page while logged out

## Testing
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_685b2119ca4c8324a4bf1402d45d4564