### PR TITLE
Add subscribe option on account page

### DIFF
--- a/app/account/components/SubscribeButton.tsx
+++ b/app/account/components/SubscribeButton.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { usePay } from '@/hooks/usePay';
+
+export function SubscribeButton() {
+  const { handlePay } = usePay();
+  return (
+    <Button size="sm" onClick={handlePay} variant="secondary">
+      Subscribe for unlimited jokes
+    </Button>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -4,6 +4,7 @@ import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { getSubscription, getUser } from '@/lib/supabase-server';
 import { UpdateSubscriptionButton } from './components/UpdateSubscriptionButton';
+import { SubscribeButton } from './components/SubscribeButton';
 
 export default async function AccountPage() {
   const [user, subscription] = await Promise.all([
@@ -39,7 +40,10 @@ export default async function AccountPage() {
               <UpdateSubscriptionButton />
             </div>
           ) : (
-            <p className="text-sm">No active subscription.</p>
+            <div className="space-y-2">
+              <p className="text-sm">No active subscription.</p>
+              <SubscribeButton />
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `SubscribeButton` component for starting subscription
- show subscribe button on account page when there is no active subscription

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_685b3684bf0c8324b3486af7895a4d59